### PR TITLE
chore: delegate to localhost

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   file:
     path: "{{ local_ssh_path }}"
     state: directory
-  connection: local
+  delegate_to: localhost
   become: false
   tags:
     - always

--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -1,5 +1,4 @@
 ---
-
 ssh_config_files:
   - ssh_host_dsa_key
   - ssh_host_dsa_key.pub
@@ -12,4 +11,4 @@ ssh_config_files:
 
 ssh_path_remote: "/etc/ssh"
 
-local_ssh_path:   "{{ local_path_base }}/{{ server_fqdn }}/ssh"
+local_ssh_path: "{{ local_path_base }}/{{ fqdn }}/ssh"


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Chore

#### Changed behavior

Use `delegate_to: localhost` instead of `connection: local` due to `ansible` requirements.

#### Breaking Changes
* `server_fqdn` to `fqdn`